### PR TITLE
fix: Fix the case where the og image url does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ async function getTag(options) {
       let image = '';
       let descriptions = '';
 
-      if (ogp.hasOwnProperty('ogImage')) {
+      if (ogp.hasOwnProperty('ogImage') && ogp.ogImage.url) {
         image += util.htmlTag('img', { src: ogp.ogImage.url } , '');
         image = util.htmlTag('div', { class: 'og-image'}, image)
       }


### PR DESCRIPTION
If the og image URL doesn't exist, it can cause problems in certain cases.