### PR TITLE
Support hexo 6

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@
 const getTag = require('./lib/generator');
 
 hexo.config.linkPreview = Object.assign({
-  descriptionLength: typeof hexo.config.linkPreview === 'undefined' ? 140 : hexo.config.linkPreview.descriptionLengt,
+  descriptionLength: typeof hexo.config.linkPreview === 'undefined' ? 140 : hexo.config.linkPreview.descriptionLength,
   className: typeof hexo.config.linkPreview.className === 'undefined' ? 'link-preview' : hexo.config.linkPreview.className,
 }, hexo.config.linkPreview);
 

--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ const getTag = require('./lib/generator');
 const { config } = hexo;
 
 hexo.config.linkPreview = Object.assign({
-  descriptionLength: typeof config.linkPreview === 'undefined' ? 140 : config.linkPreview.descriptionLength,
-  className: typeof config.linkPreview.className === 'undefined' ? 'link-preview' : config.linkPreview.className,
+  descriptionLength: hasDescriptionLength() ? config.linkPreview.descriptionLength : 140,
+  className: hasClassName() ? config.linkPreview.className : 'link-preview',
 }, config.linkPreview);
 
 hexo.extend.tag.register('linkPreview', function(args) {
@@ -27,3 +27,11 @@ hexo.extend.tag.register('linkPreview', function(args) {
     return tag;
   });
 }, {async: true});
+
+function hasDescriptionLength() {
+  return config.linkPreview && config.linkPreview.descriptionLength;
+}
+
+function hasClassName() {
+  return config.linkPreview && config.linkPreview.className;
+}

--- a/index.js
+++ b/index.js
@@ -9,11 +9,12 @@
 
 'use strict';
 const getTag = require('./lib/generator');
+const { config } = hexo;
 
 hexo.config.linkPreview = Object.assign({
-  descriptionLength: typeof hexo.config.linkPreview === 'undefined' ? 140 : hexo.config.linkPreview.descriptionLength,
-  className: typeof hexo.config.linkPreview.className === 'undefined' ? 'link-preview' : hexo.config.linkPreview.className,
-}, hexo.config.linkPreview);
+  descriptionLength: typeof config.linkPreview === 'undefined' ? 140 : config.linkPreview.descriptionLength,
+  className: typeof config.linkPreview.className === 'undefined' ? 'link-preview' : config.linkPreview.className,
+}, config.linkPreview);
 
 hexo.extend.tag.register('linkPreview', function(args) {
   return getTag({url: args[0], target: args[1], rel: args[2]}).then(tag => {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,13 @@ hexo.config.linkPreview = Object.assign({
 }, config.linkPreview);
 
 hexo.extend.tag.register('linkPreview', function(args) {
-  return getTag({url: args[0], target: args[1], rel: args[2]}).then(tag => {
+  return getTag({
+    url: args[0],
+    target: args[1],
+    rel: args[2],
+    descriptionLength: config.linkPreview.descriptionLength,
+    className: config.linkPreview.className,
+  }).then(tag => {
     return tag;
   });
 }, {async: true});

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1,12 +1,10 @@
 'use strict';
 
-const hexo = require('hexo');
 const util = require('hexo-util');
 const ogs = require('open-graph-scraper');
 const escapeHTML = require('escape-html');
 
 module.exports = async function(options) {
-  const { config } = hexo;
   return ogs(options)
     .then(function (data) {
       const ogp = data.result;
@@ -21,15 +19,15 @@ module.exports = async function(options) {
       descriptions += util.htmlTag('div', { class: 'og-title' }, escapeHTML(ogp.ogTitle), false);
 
       if (ogp.hasOwnProperty('ogDescription')) {
-        const description = (ogp.ogDescription && ogp.ogDescription.length > config.linkPreview.descriptionLength) ?
-          ogp.ogDescription.slice(0, config.linkPreview.descriptionLength) + '…' : ogp.ogDescription;
+        const description = (ogp.ogDescription && ogp.ogDescription.length > options.descriptionLength) ?
+          ogp.ogDescription.slice(0, options.descriptionLength) + '…' : ogp.ogDescription;
         descriptions += util.htmlTag('div', { class: 'og-description' }, escapeHTML(description), false);
       }
 
       descriptions = util.htmlTag('div', { class: 'descriptions' }, descriptions, false);
 
       const tag = util.htmlTag('div', { class: 'link-area' },  image + descriptions, false);
-      return util.htmlTag('a', { href: options.url, class: config.className, target: options.target, rel: options.rel }, tag, false);
+      return util.htmlTag('a', { href: options.url, class: options.className, target: options.target, rel: options.rel }, tag, false);
     })
     .catch(function (error) {
       console.log('error:', error);

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1,11 +1,12 @@
 'use strict';
 
+const hexo = require('hexo');
 const util = require('hexo-util');
 const ogs = require('open-graph-scraper');
 const escapeHTML = require('escape-html');
 
 module.exports = async function(options) {
-  const config = this.config;
+  const { config } = hexo;
   return ogs(options)
     .then(function (data) {
       const ogp = data.result;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "open-graph-scraper": "^4.11.0"
       },
       "devDependencies": {
-        "hexo": "^5.4.0",
+        "hexo": "^6.0.0",
         "jest": "^27.4.2"
       }
     },
@@ -2120,6 +2120,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/fast-equals": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
+      "integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w==",
+      "dev": true
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2339,26 +2345,27 @@
       }
     },
     "node_modules/hexo": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/hexo/-/hexo-5.4.0.tgz",
-      "integrity": "sha512-4vMDle5GjpMeOVrx0NKoTZCqrmpJVg3wNiNNUVjcoFfcpYcMzQUCZHBtQqLl7BzjJ8x2gs002VQ5yv0ZKtj8Jg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hexo/-/hexo-6.0.0.tgz",
+      "integrity": "sha512-ffSOhOEwPCJt2Ch4DdCdX39WBv8IX8I8I7md08RMDYc6jqxmE2mpuU8wzFYEJ/FQVjrt/EsQ/qfKAz3zAW/hvw==",
       "dev": true,
       "dependencies": {
         "abbrev": "^1.1.1",
         "archy": "^1.0.0",
         "bluebird": "^3.5.2",
-        "chalk": "^4.0.0",
         "hexo-cli": "^4.0.0",
         "hexo-front-matter": "^2.0.0",
         "hexo-fs": "^3.1.0",
         "hexo-i18n": "^1.0.0",
-        "hexo-log": "^2.0.0",
+        "hexo-log": "^3.0.0",
         "hexo-util": "^2.4.0",
         "js-yaml": "^4.0.0",
         "micromatch": "^4.0.2",
+        "moize": "^6.1.0",
         "moment": "^2.22.2",
         "moment-timezone": "^0.5.21",
         "nunjucks": "^3.2.1",
+        "picocolors": "^1.0.0",
         "pretty-hrtime": "^1.0.3",
         "resolve": "^1.8.1",
         "strip-ansi": "^6.0.0",
@@ -2371,7 +2378,7 @@
         "hexo": "bin/hexo"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=12.13.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2484,6 +2491,18 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/hexo/node_modules/hexo-log": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hexo-log/-/hexo-log-3.0.0.tgz",
+      "integrity": "sha512-fd87qXYznpNTa8SLov+wjDsrPssk4yKSgdIQg1wJPcuthy8ngvbXYdqaJ4vWMSADZ+D257EmKXTJHJyaxJQhVw==",
+      "dev": true,
+      "dependencies": {
+        "nanocolors": "^0.2.12"
+      },
+      "engines": {
+        "node": ">=12.4.0"
+      }
     },
     "node_modules/hexo/node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3699,6 +3718,12 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "node_modules/micro-memoize": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/micro-memoize/-/micro-memoize-4.0.9.tgz",
+      "integrity": "sha512-Z2uZi/IUMGQDCXASdujXRqrXXEwSY0XffUrAOllhqzQI3wpUyZbiZTiE2JuYC0HSG2G7DbCS5jZmsEKEGZuemg==",
+      "dev": true
+    },
     "node_modules/micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -3776,6 +3801,16 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "node_modules/moize": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/moize/-/moize-6.1.0.tgz",
+      "integrity": "sha512-WrMcM+C2Jy+qyOC/UMhA3BCHGowxV34dhDZnDNfxsREW/8N+33SFjmc23Q61Xv1WUthUA1vYopTitP1sZ5jkeg==",
+      "dev": true,
+      "dependencies": {
+        "fast-equals": "^2.0.1",
+        "micro-memoize": "^4.0.9"
+      }
+    },
     "node_modules/moment": {
       "version": "2.25.3",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
@@ -3801,6 +3836,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/nanocolors": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.13.tgz",
+      "integrity": "sha512-0n3mSAQLPpGLV9ORXT5+C/D4mwew7Ebws69Hx4E2sgz2ZA5+32Q80B9tL8PbL7XHnRDiAxH/pnrUJ9a4fkTNTA==",
       "dev": true
     },
     "node_modules/natural-compare": {
@@ -6595,6 +6636,12 @@
         }
       }
     },
+    "fast-equals": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
+      "integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w==",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -6758,26 +6805,27 @@
       "dev": true
     },
     "hexo": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/hexo/-/hexo-5.4.0.tgz",
-      "integrity": "sha512-4vMDle5GjpMeOVrx0NKoTZCqrmpJVg3wNiNNUVjcoFfcpYcMzQUCZHBtQqLl7BzjJ8x2gs002VQ5yv0ZKtj8Jg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hexo/-/hexo-6.0.0.tgz",
+      "integrity": "sha512-ffSOhOEwPCJt2Ch4DdCdX39WBv8IX8I8I7md08RMDYc6jqxmE2mpuU8wzFYEJ/FQVjrt/EsQ/qfKAz3zAW/hvw==",
       "dev": true,
       "requires": {
         "abbrev": "^1.1.1",
         "archy": "^1.0.0",
         "bluebird": "^3.5.2",
-        "chalk": "^4.0.0",
         "hexo-cli": "^4.0.0",
         "hexo-front-matter": "^2.0.0",
         "hexo-fs": "^3.1.0",
         "hexo-i18n": "^1.0.0",
-        "hexo-log": "^2.0.0",
+        "hexo-log": "^3.0.0",
         "hexo-util": "^2.4.0",
         "js-yaml": "^4.0.0",
         "micromatch": "^4.0.2",
+        "moize": "^6.1.0",
         "moment": "^2.22.2",
         "moment-timezone": "^0.5.21",
         "nunjucks": "^3.2.1",
+        "picocolors": "^1.0.0",
         "pretty-hrtime": "^1.0.3",
         "resolve": "^1.8.1",
         "strip-ansi": "^6.0.0",
@@ -6792,6 +6840,15 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
+        },
+        "hexo-log": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/hexo-log/-/hexo-log-3.0.0.tgz",
+          "integrity": "sha512-fd87qXYznpNTa8SLov+wjDsrPssk4yKSgdIQg1wJPcuthy8ngvbXYdqaJ4vWMSADZ+D257EmKXTJHJyaxJQhVw==",
+          "dev": true,
+          "requires": {
+            "nanocolors": "^0.2.12"
+          }
         },
         "js-yaml": {
           "version": "4.1.0",
@@ -7804,6 +7861,12 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "micro-memoize": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/micro-memoize/-/micro-memoize-4.0.9.tgz",
+      "integrity": "sha512-Z2uZi/IUMGQDCXASdujXRqrXXEwSY0XffUrAOllhqzQI3wpUyZbiZTiE2JuYC0HSG2G7DbCS5jZmsEKEGZuemg==",
+      "dev": true
+    },
     "micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -7860,6 +7923,16 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "moize": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/moize/-/moize-6.1.0.tgz",
+      "integrity": "sha512-WrMcM+C2Jy+qyOC/UMhA3BCHGowxV34dhDZnDNfxsREW/8N+33SFjmc23Q61Xv1WUthUA1vYopTitP1sZ5jkeg==",
+      "dev": true,
+      "requires": {
+        "fast-equals": "^2.0.1",
+        "micro-memoize": "^4.0.9"
+      }
+    },
     "moment": {
       "version": "2.25.3",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
@@ -7879,6 +7952,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "nanocolors": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.13.tgz",
+      "integrity": "sha512-0n3mSAQLPpGLV9ORXT5+C/D4mwew7Ebws69Hx4E2sgz2ZA5+32Q80B9tL8PbL7XHnRDiAxH/pnrUJ9a4fkTNTA==",
       "dev": true
     },
     "natural-compare": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hexo-tag-link-preview",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hexo-tag-link-preview",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "escape-html": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "open-graph-scraper": "^4.11.0"
   },
   "devDependencies": {
-    "hexo": "^5.4.0",
+    "hexo": "^6.0.0",
     "jest": "^27.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-tag-link-preview",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Embed a link preview on your Hexo article.",
   "main": "index.js",
   "scripts": {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -15,12 +15,14 @@ beforeAll(async() => {
   result = await generator({
     url: 'https://ogp.me/',
     target: '_blank',
-    rel: 'nofollow'
+    rel: 'nofollow',
+    className: 'link-preview',
+    descriptionLength: 6,
   });
 });
 
 test('get link preview from https://ogp.me/', async() => {
   expect(result).toBe(
-    '<a href="https://ogp.me/" target="_blank" rel="nofollow"><div class="link-area"><div class="og-image"><img src="https://ogp.me/logo.png"></img></div><div class="descriptions"><div class="og-title">Open Graph protocol</div><div class="og-description">The Op…</div></div></div></a>'
+    '<a href="https://ogp.me/" class="link-preview" target="_blank" rel="nofollow"><div class="link-area"><div class="og-image"><img src="https://ogp.me/logo.png"></img></div><div class="descriptions"><div class="og-title">Open Graph protocol</div><div class="og-description">The Op…</div></div></div></a>'
   );
 });


### PR DESCRIPTION
[v1.3.0](https://github.com/minamo173/hexo-tag-link-preview/releases/tag/v1.3.0) with hexo 6.0.0 causes error.
In [v1.3.0](https://github.com/minamo173/hexo-tag-link-preview/releases/tag/v1.3.0), I think cause changed to refer hexo config object.

## changed
+ refer way hexo config object
+ updated packages

## related issue
#79 